### PR TITLE
Added decoder error cases, Fixed renderingLayer init timing issue

### DIFF
--- a/VersaPlayer/Classes/Source/Core/Enums/VersaPlayerPlaybackError.swift
+++ b/VersaPlayer/Classes/Source/Core/Enums/VersaPlayerPlaybackError.swift
@@ -17,6 +17,8 @@ public enum VersaPlayerPlaybackError {
     case mediaFileError
     case bandwidthExceeded
     case playlistUnchanged
+    case decoderMalfunction
+    case decoderTemporarilyUnavailable
     case wrongHostIP
     case wrongHostDNS
     case badURL

--- a/VersaPlayer/Classes/Source/Core/Player/VersaPlayer.swift
+++ b/VersaPlayer/Classes/Source/Core/Player/VersaPlayer.swift
@@ -180,7 +180,7 @@ extension VersaPlayer {
             case "status":
                 if let value = change?[.newKey] as? Int, let status = AVPlayerItem.Status(rawValue: value), let item = object as? AVPlayerItem {
                     if status == .failed, let error = item.error as NSError?, let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError {
-                        var playbackError = VersaPlayerPlaybackError.unknown
+                        let playbackError: VersaPlayerPlaybackError
                         switch underlyingError.code {
                         case -12937:
                             playbackError = .authenticationError
@@ -198,6 +198,10 @@ extension VersaPlayer {
                             playbackError = .bandwidthExceeded
                         case -12642:
                             playbackError = .playlistUnchanged
+                        case -12911:
+                            playbackError = .decoderMalfunction
+                        case -12913:
+                            playbackError = .decoderTemporarilyUnavailable
                         case -1004:
                             playbackError = .wrongHostIP
                         case -1003:

--- a/VersaPlayer/Classes/Source/Core/Rendering/VersaPlayerRenderingView.swift
+++ b/VersaPlayer/Classes/Source/Core/Rendering/VersaPlayerRenderingView.swift
@@ -33,6 +33,7 @@ open class VersaPlayerRenderingView: View {
     ///     - player: VersaPlayer instance to render.
     public init(with player: VersaPlayerView) {
         super.init(frame: CGRect.zero)
+        initializeRenderingLayer(with: player)
         self.player = player
     }
     
@@ -42,25 +43,25 @@ open class VersaPlayerRenderingView: View {
     
     #if os(macOS)
     
+    private func initializeRenderingLayer(with player: VersaPlayerView) {
+        renderingLayer = VersaPlayerLayer.init(with: player)
+        layer = renderingLayer.playerLayer
+    }
+    
     open override func layout() {
         super.layout()
-        if renderingLayer == nil {
-            renderingLayer = VersaPlayerLayer.init(with: player)
-            layer = renderingLayer.playerLayer
-        }
-        
         renderingLayer.playerLayer.frame = bounds
     }
     
     #else
     
+    private func initializeRenderingLayer(with player: VersaPlayerView) {
+        renderingLayer = VersaPlayerLayer.init(with: player)
+        layer.addSublayer(renderingLayer.playerLayer)
+    }
+    
     open override func layoutSubviews() {
         super.layoutSubviews()
-        if renderingLayer == nil {
-            renderingLayer = VersaPlayerLayer.init(with: player)
-            layer.addSublayer(renderingLayer.playerLayer)
-        }
-        
         renderingLayer.playerLayer.frame = bounds
     }
     


### PR DESCRIPTION
I've fixed up a couple of issues I've encountered in my app. See individual comments on commits for more details.

I intended to hard-fork this repo to fix other issues like nasty memory leaks (too many strong reference cycles) but turns out you guys have done fixing the issue already, so I decided to help you a little bit as well 😄

Edit: There's actually a chance you really want to delay the initialization of the renderingLayer because the `AVPlayerLayer` starts rendering as soon as an `AVPlayerItem` is given and is added to the layer/view hierarchy, which may start occupying computing resources of a running device unwantedly. But you can easily prevent this by not adding `VersaPlayer` into your view hierarchy. I've confirmed that unless you don't add it to the view hierarchy to render, an underlying `AVPlayerLayer` does not start doing anything even if it is supplied with an `AVPlayerItem`. I believe this should be safe!