### PR TITLE
Fix retain cycle issue with the "nonFullscreenContainer" property

### DIFF
--- a/VersaPlayer/Classes/Source/VersaPlayerView.swift
+++ b/VersaPlayer/Classes/Source/VersaPlayerView.swift
@@ -57,7 +57,7 @@ open class VersaPlayerView: View, PIPProtocol {
     public weak var decryptionDelegate: VersaPlayerDecryptionDelegate? = nil
     
     /// VersaPlayer initial container
-    private var nonFullscreenContainer: View!
+    private weak var nonFullscreenContainer: View!
     
     #if os(iOS)
     /// AVPictureInPictureController instance


### PR DESCRIPTION
When you enter fullscreen mode and back to normal mode. then you dismiss or pop the viewController Player keeps playing in the background which leads me to think the playerView is not released from Memory. This happens with the provided TestProject.
I think there is a retain cycle issue with the "nonFullscreenContainer" property, making it weak solved the problem for me.