### PR TITLE
Added unversioned TeamID infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ Carthage/Build
 # `pod install` in .travis.yml
 #
 # Pods/
+
+# User-specific xcconfig files
+Examples/Xcode-config/DEVELOPMENT_TEAM.xcconfig

--- a/Examples/VersaPlayerTest.xcodeproj/project.pbxproj
+++ b/Examples/VersaPlayerTest.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -49,6 +49,8 @@
 		11C1C19D2191550F00A4F7D5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2FFE1673769B2B47DCD4E8E6 /* Pods-VersaPlayerTest_macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VersaPlayerTest_macOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-VersaPlayerTest_macOS/Pods-VersaPlayerTest_macOS.release.xcconfig"; sourceTree = "<group>"; };
 		32F71FE5298C24E4B80EDF06 /* Pods-VersaPlayerTest_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VersaPlayerTest_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-VersaPlayerTest_iOS/Pods-VersaPlayerTest_iOS.release.xcconfig"; sourceTree = "<group>"; };
+		3DF592DA24CDC022002AB260 /* DEVELOPMENT_TEAM.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DEVELOPMENT_TEAM.xcconfig; sourceTree = "<group>"; };
+		3DF592DB24CDC022002AB260 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		6E00691A79E2D954E582531F /* Pods_VersaPlayerTest_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VersaPlayerTest_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A283B97A087CE29BBF21C985 /* Pods-VersaPlayerTest_tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VersaPlayerTest_tvOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VersaPlayerTest_tvOS/Pods-VersaPlayerTest_tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		B16666E571659532CAD4D771 /* Pods-VersaPlayerTest_macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VersaPlayerTest_macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VersaPlayerTest_macOS/Pods-VersaPlayerTest_macOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -88,6 +90,7 @@
 		11C1C11721912DB200A4F7D5 = {
 			isa = PBXGroup;
 			children = (
+				3DF592D924CDC022002AB260 /* Xcode-config */,
 				11C1C12221912DB200A4F7D5 /* VersaPlayerTest */,
 				11C1C16A219146CF00A4F7D5 /* VersaPlayerTest_iOS */,
 				11C1C1932191550D00A4F7D5 /* VersaPlayerTest_tvOS */,
@@ -153,6 +156,15 @@
 				07B70CAE23E36CCC7131A726 /* Pods_VersaPlayerTest_tvOS.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3DF592D924CDC022002AB260 /* Xcode-config */ = {
+			isa = PBXGroup;
+			children = (
+				3DF592DA24CDC022002AB260 /* DEVELOPMENT_TEAM.xcconfig */,
+				3DF592DB24CDC022002AB260 /* Shared.xcconfig */,
+			);
+			path = "Xcode-config";
 			sourceTree = "<group>";
 		};
 		A7FBCA3A635E05A7FC92317E /* Pods */ = {
@@ -503,6 +515,7 @@
 /* Begin XCBuildConfiguration section */
 		11C1C12E21912DB300A4F7D5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DF592DB24CDC022002AB260 /* Shared.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -564,6 +577,7 @@
 		};
 		11C1C12F21912DB300A4F7D5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DF592DB24CDC022002AB260 /* Shared.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/Examples/Xcode-config/Shared.xcconfig
+++ b/Examples/Xcode-config/Shared.xcconfig
@@ -1,0 +1,65 @@
+#include? "DEVELOPMENT_TEAM.xcconfig"
+
+// Create the file DEVELOPMENT_TEAM.xcconfig
+// in the "Xcode-config" directory within the project directory
+// with the following build setting:
+// DEVELOPMENT_TEAM = [Your TeamID]
+
+// Hint: recent Xcode versions appear to automatically create an empty file 
+// for you on the first build. This build will fail, or course, 
+// because code-signing can’t work without the DEVELOPMENT_TEAM set. 
+// Just fill it in and everything should work. 
+
+// The following is based on https://stackoverflow.com/a/47732584:
+// Set up “Accounts” in Xcode’s preferences with the Apple ID you want to use for development.
+// On macOS, you can then find your personal team ID in the keychain.
+// Your developer and distribution certificates have your Team ID in them.
+// To access your keychain, open the “Keychain Access” app:
+// /Applications/Utilities/Keychain Access
+
+// Under the ’login’ Keychain, go into the ‘Certificates’ category.
+// Scroll or search to find your development or distribution certificate.
+// The names of the certificates follows a pattern:
+// Certificate Type Name: Team Name (certificate ID)
+// where the “Certificate Type Name” is something like:
+// Developer ID Installer
+// Developer ID Application
+// 3rd Party Mac Developer Installer
+// 3rd Party Mac Developer Application
+// iPhone Distribution
+// iPhone Developer
+
+// Double-click on the certificate, and the
+// “Organizational Unit”
+// is the “Team ID” you are looking for.
+
+// Note that this is the only way to find your
+// "Personal team" ID
+// You can’t find the "Personal team" ID aynwhere on Apple’s website.
+
+// You can also find your generic team ID by logging into your Apple Developer account
+// and going to
+// https://developer.apple.com/account/#/membership
+// It should be listed under “Team ID”.
+
+// To set this system up for your own project,
+// copy the "Xcode-config" directory there,
+// add it to your Xcode project,
+// navigate to your project settings
+// (root icon in the Xcode Project Navigator)
+// click on the project icon there,
+// click on the “Info” tab
+// under “Configurations”
+// open the “Debug”, “Release”,
+// and any other build configurations you might have.
+// There you can set the pull-down menus in the
+// “Based on Configuration File” column to “Shared”.
+// Done.
+
+// Don’t forget to add the DEVELOPMENT_TEAM.xcconfig file to your .gitignore:
+// # User-specific xcconfig files
+// Xcode-config/DEVELOPMENT_TEAM.xcconfig
+
+// You can now remove the “DevelopmentTeam = AB1234C5DE;” entries from the
+// .xcodeproj/project.pbxproj if you want to.
+

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ bufferingView | UIView | Shown when player is buffering
 
 #### DRM
 
-VersaPlayer also brings support for encrypted content, to make use of this funcionality you must implement VersaPlayerDecryptionDelegate and assign it to VersaPlayer's decryptionDelegate property.
+VersaPlayer also brings support for encrypted content, to make use of this functionality you must implement VersaPlayerDecryptionDelegate and assign it to VersaPlayer's decryptionDelegate property.
 
 To read more about this topic go to:
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ To run the example project, clone the repo, and run `pod install` from the Examp
   </p>
 </div>
 
+**IMPORTANT:** If you do not have an Apple ID with a developer account for code signing apps, the build  will fail with a code signing error. To work around this, you can delete the "Code Signing Identity" build setting of the "Application" target to work around the issue.
+
+**Alternatively**, if you do have a developer account, you can create the file "Examples/Xcode-config/DEVELOPMENT_TEAM.xcconfig" with the following build setting as its content:
+> DEVELOPMENT_TEAM = [Your TeamID]
+
+For a more detailed description of this, you can have a look at the comments at the end of the file "Examples/Xcode-config/Base.xcconfig". 
+
 ## Installation
 
 [CocoaPods](http://cocoapods.org) is a dependency manager for Cocoa projects.


### PR DESCRIPTION
This PR makes it possible for multiple developers to build the VersaPlayer examples out of the box after a little prep work. All everyone has to do once is to create a file called "DEVELOPMENT_TEAM.xcconfig" in the "Xcode-config" directory within the `Examples` directory with the following build setting:
DEVELOPMENT_TEAM = [personal TeamID]

This is currently to be hard-coded as "VZ7659A4W3" in the project file.

"DEVELOPMENT_TEAM.xcconfig" is excluded from versioning.

Please give it a go.