### PR TITLE
Feature/fix crash behaviour

### DIFF
--- a/Examples/VersaPlayerTest_iOS/ViewController.swift
+++ b/Examples/VersaPlayerTest_iOS/ViewController.swift
@@ -19,7 +19,7 @@ class ViewController: UIViewController {
         
         playerView.layer.backgroundColor = UIColor.black.cgColor
         playerView.use(controls: controls)
-        playerView.controls?.behaviour.shouldAutohide = true
+        playerView.controls?.behaviour?.shouldAutohide = true
         
         if let url = URL.init(string: "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8") {
             let item = VersaPlayerItem(url: url)

--- a/VersaPlayer.podspec
+++ b/VersaPlayer.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'VersaPlayer'
-    s.version          = '3.0.2'
+    s.version          = '3.0.3'
     s.summary          = 'Versatile AVPlayer implementation for iOS'
     
     s.description      = 'Versatile AVPlayer implementation for iOS.'

--- a/VersaPlayer/Classes/Source/VersaPlayerControls/VersaPlayerControls.swift
+++ b/VersaPlayer/Classes/Source/VersaPlayerControls/VersaPlayerControls.swift
@@ -24,7 +24,7 @@ open class VersaPlayerControls: View {
     public weak var handler: VersaPlayerView!
     
     /// VersaPlayerControlsBehaviour being used to validate ui
-    public var behaviour: VersaPlayerControlsBehaviour!
+    public var behaviour: VersaPlayerControlsBehaviour?
     
     #if os(iOS)
     public var airplayButton: MPVolumeView? = nil
@@ -100,7 +100,7 @@ open class VersaPlayerControls: View {
     #else
     
     open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        behaviour.hide()
+        behaviour?.hide()
     }
     
     open override func didMoveToSuperview() {
@@ -130,7 +130,7 @@ open class VersaPlayerControls: View {
         setSeekbarSlider(start: handler.player.startTime().seconds, end: handler.player.endTime().seconds, at: time.seconds)
         
         if !(handler.isSeeking || handler.isRewinding || handler.isForwarding) {
-            behaviour.update(with: time.seconds)
+            behaviour?.update(with: time.seconds)
         }
     }
     
@@ -357,7 +357,7 @@ open class VersaPlayerControls: View {
         let value = Double(sender.value)
         let time = CMTime(seconds: value, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
         handler.player.seek(to: time)
-        behaviour.update(with: time.seconds)
+        behaviour?.update(with: time.seconds)
     }
     
     /// Toggle PIP mode

--- a/VersaPlayer/Classes/Source/VersaPlayerControls/VersaPlayerControlsCoordinator.swift
+++ b/VersaPlayer/Classes/Source/VersaPlayerControls/VersaPlayerControlsCoordinator.swift
@@ -95,10 +95,10 @@ open class VersaPlayerControlsCoordinator: View, VersaPlayerGestureRecieverViewD
     /// - Parameters:
     ///     - point: CGPoint at which tap was recognized
     open func didTap(at point: CGPoint) {
-        if controls.behaviour.showingControls {
-            controls.behaviour.hide()
+        if controls.behaviour?.showingControls ?? false {
+            controls.behaviour?.hide()
         } else {
-            controls.behaviour.show()
+            controls.behaviour?.show()
         }
     }
     

--- a/VersaPlayer/Classes/Source/VersaPlayerView.swift
+++ b/VersaPlayer/Classes/Source/VersaPlayerView.swift
@@ -291,11 +291,11 @@ open class VersaPlayerView: View, PIPProtocol {
         isPipModeEnabled = true
     }
     
-    public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
+    open func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
         print(error.localizedDescription)
     }
     
-    public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
+    open func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
         
     }
     #endif


### PR DESCRIPTION
In some cases, we had crashes with force unwrapping behaviour so I passed it to optional to handle this (see below stack)

Crashed: com.apple.main-thread
0  VersaPlayer                    0x1027546e8 partial apply for closure #2 in VersaPlayerControlsBehaviour.defaultDeactivationBlock() + 92 (VersaPlayerControlsBehaviour.swift:92)
1  VersaPlayer                    0x1027542b4 thunk for @escaping @callee_guaranteed (@unowned Bool) -> () + 4333699764 (<compiler-generated>:4333699764)
2  UIKitCore                      0x23006cd1c -[UIViewAnimationBlockDelegate _didEndBlockAnimation:finished:context:] + 752
3  UIKitCore                      0x230043a74 -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 312
4  UIKitCore                      0x230044048 -[UIViewAnimationState animationDidStop:finished:] + 296
5  UIKit                          0x2234955a0 -[UIViewAnimationStateAccessibility animationDidStop:finished:] + 128
6  QuartzCore                     0x20775e3c8 CA::Layer::run_animation_callbacks(void*) + 284
7  libdispatch.dylib              0x202c4d7d4 _dispatch_client_callout + 16
8  libdispatch.dylib              0x202bfb008 _dispatch_main_queue_callback_4CF$VARIANT$mp + 1068
9  CoreFoundation                 0x2031a0b20 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
10 CoreFoundation                 0x20319ba58 __CFRunLoopRun + 1924
11 CoreFoundation                 0x20319afb4 CFRunLoopRunSpecific + 436
12 GraphicsServices               0x20539c79c GSEventRunModal + 104
13 UIKitCore                      0x22fbe1c38 UIApplicationMain + 212