### PR TITLE
Bug fix in seekbar iOS10

### DIFF
--- a/VersaPlayer/Classes/Source/VersaPlayerControls/VersaPlayerControls.swift
+++ b/VersaPlayer/Classes/Source/VersaPlayerControls/VersaPlayerControls.swift
@@ -135,6 +135,10 @@ open class VersaPlayerControls: View {
     }
     
     public func setSeekbarSlider(start startValue: Double, end endValue: Double, at time: Double) {
+        let time = time.isNaN ? 0 : time
+        let startValue = startValue.isNaN ? 0 : startValue
+        let endValue = endValue.isNaN ? 0 : endValue
+        
         #if os(macOS)
         seekbarSlider?.minValue = startValue
         seekbarSlider?.maxValue = endValue


### PR DESCRIPTION
Validations of the values to assign in the seekbar were added due to the fact that in iOS 10 there was a crash due to NaN values.