### PR TITLE
Slider issue fixes for some ios devices

### DIFF
--- a/VersaPlayer/Classes/Source/Core/Player/VersaPlayer.swift
+++ b/VersaPlayer/Classes/Source/Core/Player/VersaPlayer.swift
@@ -234,8 +234,10 @@ extension VersaPlayer {
                 isBuffering = false
                 NotificationCenter.default.post(name: VersaPlayer.VPlayerNotificationName.endBuffering.notification, object: self, userInfo: nil)
                 handler.playbackDelegate?.endBuffering(player: self)
-                guard  let item = self.currentItem as? VersaPlayerItem else { return  }
-                NotificationCenter.default.post(name: VersaPlayer.VPlayerNotificationName.timeChanged.notification, object: self, userInfo: [VPlayerNotificationInfoKey.time.rawValue: item.currentTime()])
+                
+//              iPhone XR, iOS 16.1.1, for this notification seek slider is updated with bad values, and not able to slide also
+//                guard  let item = self.currentItem as? VersaPlayerItem else { return  }
+//                NotificationCenter.default.post(name: VersaPlayer.VPlayerNotificationName.timeChanged.notification, object: self, userInfo: [VPlayerNotificationInfoKey.time.rawValue: item.currentTime()])
             case "playbackBufferFull":
                 isBuffering = false
                 NotificationCenter.default.post(name: VersaPlayer.VPlayerNotificationName.endBuffering.notification, object: self, userInfo: nil)


### PR DESCRIPTION

https://user-images.githubusercontent.com/13619184/229576077-ac2a140b-b4c6-4884-a000-8936d52ca40b.mov

In `playbackLikelyToKeepUp` state, posting `VersaPlayer.VPlayerNotificationName.timeChanged.notification` notification setting bad values to the seekslider. Also slider does not responds properly to touches.  So I commented out that.

It is happening on iPhone XR, iOS 16.1.1